### PR TITLE
fix(dir): adds way to symlink

### DIFF
--- a/inventory.yaml
+++ b/inventory.yaml
@@ -4,6 +4,6 @@ k8s_master:
     #   ansible_connection: ssh
     #   ansible_user: ubuntu
     #   ansible_port: 3013
-    doomfist:
+    orisa:
       ansible_connection: ssh
       ansible_user: tin

--- a/roles/deploy-kubernetes/tasks/main.yaml
+++ b/roles/deploy-kubernetes/tasks/main.yaml
@@ -68,6 +68,19 @@
   apt:
     deb: "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/{{ version.crioPath }}"
 
+- name: "create directory"
+  become: yes
+  file:
+    path: /usr/lib/cri-o-runc/sbin
+    state: directory
+
+- name: "hack a link"
+  become: yes
+  file:
+    src: /usr/sbin/runc
+    dest: /usr/lib/cri-o-runc/sbin/runc
+    state: link
+
 - name: "check for crictl"
   stat:
     path: /usr/local/bin/crictl

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 set -e
-ansible-playbook --ask-become-pass -i inventory.yaml deploy-k8s.yaml
+ansible-playbook -i inventory.yaml deploy-k8s.yaml
+#ansible-playbook --ask-become-pass -i inventory.yaml deploy-k8s.yaml


### PR DESCRIPTION
For some reason, the symlink of the runc from cri-o is unexpected
moved. We will just add new tasks to symlink to fix this.

Signed-off-by: Tin Lam <tin@irrational.io>